### PR TITLE
Update version package

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,26 +8,3 @@ steps:
     image: golangci/golangci-lint:v1.53.2
     commands:
       - make test
-
-  - name: dist
-    image: golang:1.20
-    environment:
-      VERSION: ${DRONE_TAG}
-      GIT_COMMIT: ${DRONE_COMMIT_SHA:0:7}
-    commands:
-      - make dist
-    when:
-      event: tag
-    depends_on:
-      - test
-
-  - name: publish
-    image: plugins/github-release
-    settings:
-      api_key:
-        from_secret: github_api_key
-      files: dist/*
-    when:
-      event: tag
-    depends_on:
-      - dist

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,3 +8,26 @@ steps:
     image: golangci/golangci-lint:v1.53.2
     commands:
       - make test
+
+  - name: dist
+    image: golang:1.20
+    environment:
+      VERSION: ${DRONE_TAG}
+      GIT_COMMIT: ${DRONE_COMMIT_SHA:0:7}
+    commands:
+      - make dist
+    when:
+      event: tag
+    depends_on:
+      - test
+
+  - name: publish
+    image: plugins/github-release
+    settings:
+      api_key:
+        from_secret: github_api_key
+      files: dist/*
+    when:
+      event: tag
+    depends_on:
+      - dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /_dist
 /ksec
 /ksec.exe
+plugin.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/_dist
+/bin
+/dist
 /ksec
 /ksec.exe
 plugin.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-DIST := $(CURDIR)/_dist
-VERSION := $(shell grep '^const Version =' pkg/version/version.go | cut -d\" -f2)
+MODULE := github.com/kanopy-platform/ksec
+CMD_NAME := ksec
+
+VERSION ?= dirty
+GIT_COMMIT := $(shell git rev-parse HEAD)
+LDFLAGS = "-X '${MODULE}/internal/version.version=${VERSION}' -X '${MODULE}/internal/version.gitCommit=${GIT_COMMIT}'"
 
 .PHONY: all
 all: test build
@@ -14,17 +18,36 @@ build:
 	go install ./cmd/ksec/
 
 .PHONY: dist
-dist:
-	mkdir -p $(DIST)
-	GOOS=linux GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-linux-amd64-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
-	GOOS=darwin GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-amd64-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
-	GOOS=darwin GOARCH=arm64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-arm64-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
-	GOOS=windows GOARCH=amd64 go build -o ksec.exe ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-windows-amd64-$(VERSION).tgz ksec.exe README.md LICENSE plugin.yaml
+dist: dist-setup dist-linux dist-darwin dist-windows ## Cross compile binaries into ./dist/
+
+.PHONY: dist-setup
+dist-setup:
+	mkdir -p ./bin ./dist
+	./scripts/plugin.yaml.sh ${VERSION}
+
+.PHONY: dist-build
+dist-build: BIN_NAME=${CMD_NAME}-${GOOS}-${GOARCH}-${VERSION}${FILE_EXT}
+dist-build:
+	go build -ldflags=$(LDFLAGS) -o ./bin/$(BIN_NAME) ./cmd/$(CMD_NAME)/
+	tar -zcvf dist/$(BIN_NAME).tgz ./bin/$(BIN_NAME) README.md LICENSE plugin.yaml
+
+.PHONY: dist-amd-arm
+dist-amd-arm:
+	@$(MAKE) GOARCH=amd64 dist-build
+	@$(MAKE) GOARCH=arm64 dist-build
+
+.PHONY: dist-linux
+dist-linux:
+	@$(MAKE) GOOS=linux dist-amd-arm
+
+.PHONY: dist-darwin
+dist-darwin:
+	@$(MAKE) GOOS=darwin dist-amd-arm
+
+.PHONY: dist-windows
+dist-windows:
+	@$(MAKE) GOOS=windows FILE_EXT=.exe dist-amd-arm
 
 .PHONY: clean
 clean:
-	rm -rf ./_dist ./ksec*
+	rm -rf ./bin ./dist plugin.yaml

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Use "ksec [command] --help" for more information about a command.
 
 Run `make` to run all tests and create a new binary in `${GOPATH}/bin/`
 
-Run `make dist` to cross compile binaries into a `./_dist/` directory. These binaries can then be uploaded to a new GitHub release.
+Run `VERSION=<version_number> make dist` to cross compile binaries into a `./dist/` directory. These binaries can then be uploaded to a new GitHub release.

--- a/cmd/ksec/main.go
+++ b/cmd/ksec/main.go
@@ -9,8 +9,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/kanopy-platform/ksec/internal/version"
 	"github.com/kanopy-platform/ksec/pkg/models"
-	"github.com/kanopy-platform/ksec/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,7 +54,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "ksec",
 		Short:   "A tool for managing Kubernetes Secret data",
-		Version: version.Version,
+		Version: version.Get().Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error
 			secretsClient, err = models.NewSecretsClient(viper.GetString("namespace"))

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/kanopy-platform/ksec/pkg/models"
-	"github.com/kanopy-platform/ksec/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +17,8 @@ var rootCmd *cobra.Command
 
 func TestMain(m *testing.M) {
 	rootCmd = &cobra.Command{
-		Use:     "ksec",
-		Short:   "A tool for managing Kubernetes Secret data",
-		Version: version.Version,
+		Use:   "ksec",
+		Short: "A tool for managing Kubernetes Secret data",
 	}
 	initRootCmd(rootCmd)
 	secretsClient = models.MockNewSecretsClient()
@@ -28,7 +26,7 @@ func TestMain(m *testing.M) {
 
 }
 
-//helpers
+// helpers
 func testErr(err error, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,19 @@
+package version
+
+var (
+	// these are set using ldflags
+	version   = ""
+	gitCommit = ""
+)
+
+type Info struct {
+	Version   string `json:"version,omitempty"`
+	GitCommit string `json:"gitCommit,omitempty"`
+}
+
+func Get() Info {
+	return Info{
+		Version:   version,
+		GitCommit: gitCommit,
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,0 @@
-package version
-
-// Version sets the release version for ksec
-const Version = "0.1.6"

--- a/scripts/plugin.yaml.sh
+++ b/scripts/plugin.yaml.sh
@@ -1,10 +1,14 @@
+#!/bin/bash
+
+cat <<EOF > "plugin.yaml"
 ---
 name: "ksec"
-version: "0.1.6"
+version: "${1}"
 usage: "Manage Kubernetes Secrets through Helm"
 description: "Helm plugin that simplifies the management of Kubernetes Secrets"
 ignoreFlags: false
 useTunnel: false
-command: "$HELM_PLUGIN_DIR/ksec"
+command: "\$HELM_PLUGIN_DIR/ksec"
 hooks:
-  install: "cd $HELM_PLUGIN_DIR && scripts/install-binary.sh"
+  install: "cd \$HELM_PLUGIN_DIR && scripts/install-binary.sh"
+EOF


### PR DESCRIPTION
This refactors the distribution tooling to build all {linux,darwin,windows} * {amd,arm} variants and updates the internal `version` package to set the version from the environment using ldflags.

You can test building for a specific version using:
```
VERSION=test make dist
```